### PR TITLE
added augmented_splay_tree

### DIFF
--- a/splay Tree/Augmented Splay Tree/program.c
+++ b/splay Tree/Augmented Splay Tree/program.c
@@ -1,0 +1,135 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef struct Node {
+    int key;
+    int size;
+    struct Node *left, *right;
+} Node;
+
+// Utility function to create a new node
+Node* newNode(int key) {
+    Node* node = (Node*)malloc(sizeof(Node));
+    node->key = key;
+    node->size = 1;
+    node->left = node->right = NULL;
+    return node;
+}
+
+// Updates the size of a node based on its children
+void updateSize(Node *node) {
+    if (node != NULL) {
+        node->size = 1 + (node->left ? node->left->size : 0) + (node->right ? node->right->size : 0);
+    }
+}
+
+// Perform right rotation
+Node* rightRotate(Node* y) {
+    Node* x = y->left;
+    y->left = x->right;
+    x->right = y;
+    updateSize(y);
+    updateSize(x);
+    return x;
+}
+
+// Perform left rotation
+Node* leftRotate(Node* x) {
+    Node* y = x->right;
+    x->right = y->left;
+    y->left = x;
+    updateSize(x);
+    updateSize(y);
+    return y;
+}
+
+// Splay operation to bring a key to the root of the tree
+Node* splay(Node* root, int key) {
+    if (root == NULL || root->key == key)
+        return root;
+
+    if (key < root->key) {
+        if (root->left == NULL) return root;
+
+        if (key < root->left->key) {
+            root->left->left = splay(root->left->left, key);
+            root = rightRotate(root);
+        } else if (key > root->left->key) {
+            root->left->right = splay(root->left->right, key);
+            if (root->left->right) root->left = leftRotate(root->left);
+        }
+        return (root->left == NULL) ? root : rightRotate(root);
+    } else {
+        if (root->right == NULL) return root;
+
+        if (key > root->right->key) {
+            root->right->right = splay(root->right->right, key);
+            root = leftRotate(root);
+        } else if (key < root->right->key) {
+            root->right->left = splay(root->right->left, key);
+            if (root->right->left) root->right = rightRotate(root->right);
+        }
+        return (root->right == NULL) ? root : leftRotate(root);
+    }
+}
+
+// Insert a new key in the augmented splay tree
+Node* insert(Node* root, int key) {
+    if (root == NULL) return newNode(key);
+
+    root = splay(root, key);
+    if (root->key == key) return root;
+
+    Node* new_node = newNode(key);
+    if (key < root->key) {
+        new_node->right = root;
+        new_node->left = root->left;
+        root->left = NULL;
+    } else {
+        new_node->left = root;
+        new_node->right = root->right;
+        root->right = NULL;
+    }
+    updateSize(root);
+    updateSize(new_node);
+    return new_node;
+}
+
+// Find the k-th smallest element in the tree
+Node* findKthSmallest(Node* root, int k) {
+    if (root == NULL || k <= 0 || k > root->size) return NULL;
+
+    int leftSize = root->left ? root->left->size : 0;
+    if (k == leftSize + 1) return root;
+    else if (k <= leftSize) return findKthSmallest(root->left, k);
+    else return findKthSmallest(root->right, k - leftSize - 1);
+}
+
+// Print in-order traversal
+void inorder(Node* root) {
+    if (root != NULL) {
+        inorder(root->left);
+        printf("%d ", root->key);
+        inorder(root->right);
+    }
+}
+
+int main() {
+    Node* root = NULL;
+
+    root = insert(root, 20);
+    root = insert(root, 15);
+    root = insert(root, 25);
+    root = insert(root, 10);
+    root = insert(root, 5);
+
+    printf("In-order traversal of the augmented splay tree:\n");
+    inorder(root);
+
+    int k = 3;
+    Node* kthNode = findKthSmallest(root, k);
+    if (kthNode) printf("\n%d-th smallest element is %d\n", k, kthNode->key);
+    else printf("\n%d-th smallest element does not exist\n", k);
+
+    return 0;
+}

--- a/splay Tree/Augmented Splay Tree/readme.md
+++ b/splay Tree/Augmented Splay Tree/readme.md
@@ -1,0 +1,52 @@
+# Augmented Splay Tree (Order Statistic Tree)
+
+## Description
+An Augmented Splay Tree is an advanced form of a splay tree that includes additional information to efficiently support *order statistics* operations, such as finding the k-th smallest or largest element. By maintaining subtree sizes for each node, this augmented structure allows for efficient rank queries and order-based operations, making it suitable for scenarios where data access frequency varies and order-based retrievals are needed.
+
+### Problem Definition
+The goal is to implement an augmented splay tree that efficiently supports the following operations:
+
+1. **Insertion of elements**, followed by a splay operation to move the inserted node to the root, with subtree size adjustments.
+2. **Deletion of elements**, which involves splaying the node to be deleted before removal and adjusting subtree sizes accordingly.
+3. **Order-based queries**, including finding the k-th smallest or largest element and rank queries.
+4. **Tree traversals** to visit nodes in specific orders (in-order, pre-order, post-order), maintaining subtree size information.
+
+### Algorithm Review
+
+1. **Insertion**
+   - Insert the node as in a standard splay tree.
+   - Adjust subtree sizes during the insertion.
+   - Perform a splay operation to bring the inserted node to the root, adjusting subtree sizes as needed.
+
+2. **Deletion**
+   - Splay the tree to bring the target node to the root.
+   - Remove the root node, reconnect left and right subtrees, and adjust subtree sizes.
+   - Splay the new root to maintain the splay tree properties and adjust subtree sizes accordingly.
+
+3. **Order-based Queries**
+   - **K-th Smallest/Largest**: Use subtree sizes to navigate to the k-th element efficiently.
+   - **Rank Query**: Determine the rank of an element based on subtree sizes while navigating the tree.
+
+4. **Tree Traversals**
+   - **In-order traversal (LNR)**: Visits nodes in sorted order.
+   - **Pre-order traversal (NLR)**: Visits root first, followed by left and right subtrees.
+   - **Post-order traversal (LRN)**: Visits children first, followed by the root.
+
+5. **Splaying**
+   - **Zig Rotation**: Used when the accessed node is the child of the root.
+   - **Zig-Zig Rotation**: Used when both node and parent are either left or right children.
+   - **Zig-Zag Rotation**: Used when the node is a right child of a left parent or a left child of a right parent.
+
+### Time Complexity
+The time complexity of operations in an Augmented Splay Tree is as follows:
+
+- **Insertion**: Amortized O(log n)
+  - Each insertion adjusts subtree sizes and performs splaying, resulting in O(log n) on average.
+
+- **Deletion**: Amortized O(log n)
+  - Deletion includes finding the node, updating subtree sizes, and rebalancing via splaying.
+
+- **Order-based Queries**: Amortized O(log n)
+  - K-th smallest/largest and rank queries operate in O(log n) using subtree size information.
+
+- **Traversal**: O(n)


### PR DESCRIPTION
# Add Section on Order Statistic Trees (Augmented Splay Trees) to Splay Trees 

## Description
This PR introduces a new section to the Splay Trees documentation focused on Order Statistic Trees, specifically augmenting splay trees to support order statistics efficiently.

Please review and merge it under gssoc-ext and hacktoberfest along with levels.