### PR TITLE
maximalRectangle

### DIFF
--- a/Dynamic Programming/maximal rectangle/README.md
+++ b/Dynamic Programming/maximal rectangle/README.md
@@ -1,0 +1,48 @@
+Problem Overview
+The task is to find the largest rectangle containing only 1's in a given binary matrix. Each element in the matrix is either '0' or '1', and we want to calculate the maximum area of contiguous '1's that can form a rectangle.
+
+Approach
+The problem can be approached using the concept of dynamic histogram heights, where each row of the matrix is treated as a base and we calculate the histogram height of each column based on the presence of '1's in the rows above it. This allows us to use techniques similar to finding the largest rectangle in a histogram for each row, which can be efficiently solved with the following steps.
+
+Steps to Solve
+Initialize Arrays:
+
+heights[]: Stores the height of '1's for each column. At any row i, if matrix[i][j] is '1', the height at heights[j] is incremented; otherwise, it's reset to 0.
+leftBoundaries[]: Tracks the left boundary (leftmost column where '1's can extend) for each column in the current row.
+rightBoundaries[]: Tracks the right boundary (rightmost column where '1's can extend) for each column in the current row.
+Row-by-Row Processing:
+
+For each row, update the heights[], leftBoundaries[], and rightBoundaries[] arrays.
+Calculate the maximum area for each rectangle ending at each column by multiplying the height by the width defined by the difference between the right and left boundaries.
+Calculate Maximum Rectangle Area:
+
+For each column, calculate the rectangle area using the formula area = height * (rightBoundary - leftBoundary).
+Update maxRectangle with the maximum area encountered.
+Helper Functions
+updateHeightsAndLeftBoundaries: Updates the heights[] array and leftBoundaries[] for the current row. If matrix[i][j] is '1', heights[j] is incremented, and leftBoundaries[j] is updated based on the current left boundary. Otherwise, heights[j] is reset to 0, and the left boundary is updated.
+
+updateRightBoundaries: Updates the rightBoundaries[] array for the current row. If matrix[i][j] is '1', rightBoundaries[j] is updated based on the current right boundary. If not, rightBoundaries[j] is reset, and right is adjusted.
+
+calculateMaxRectangle: Iterates over each column and calculates the area for each possible rectangle using heights, leftBoundaries, and rightBoundaries. It then updates maxRectangle if a larger area is found.
+
+Complexity Analysis
+Time Complexity: 
+𝑂
+(
+𝑚
+×
+𝑛
+)
+O(m×n), where 
+𝑚
+m is the number of rows and 
+𝑛
+n is the number of columns. Each cell is processed once, and boundary updates are linear.
+Space Complexity: 
+𝑂
+(
+𝑛
+)
+O(n), for storing heights, leftBoundaries, and rightBoundaries.
+Summary
+This approach leverages a dynamic programming technique to keep track of heights and boundaries, transforming the problem into a maximal rectangle calculation on each row as if it were a histogram. By iteratively updating the boundaries and heights, we efficiently compute the maximal rectangle area in a binary matrix. This method ensures that the solution is optimal for large matrices while maintaining manageable space complexity.


### PR DESCRIPTION
Given a rows x cols binary matrix filled with 0's and 1's, find the largest rectangle containing only 1's and return its area.

 

Example 1:


Input: matrix = [["1","0","1","0","0"],["1","0","1","1","1"],["1","1","1","1","1"],["1","0","0","1","0"]]
Output: 6
Explanation: The maximal rectangle is shown in the above picture.
Example 2:

Input: matrix = [["0"]]
Output: 0
Example 3:

Input: matrix = [["1"]]
Output: 1
 

Constraints:

rows == matrix.length
cols == matrix[i].length
1 <= row, cols <= 200
matrix[i][j] is '0' or '1'